### PR TITLE
Extract used enums from query variables

### DIFF
--- a/graphql-codegen-haskell/src/parse/operation.ts
+++ b/graphql-codegen-haskell/src/parse/operation.ts
@@ -3,6 +3,7 @@ import {
   DocumentNode,
   GraphQLObjectType,
   GraphQLSchema,
+  isEnumType,
   Kind,
   OperationDefinitionNode,
   print as renderGraphQLNode,
@@ -112,6 +113,16 @@ class OperationDefinitionParser {
         `Unable to find root schema type for operation type "${node.operation}"`
       )
     }
+
+    node.variableDefinitions?.forEach((v) => {
+      let type = v.type.kind == "NonNullType" ? v.type.type : v.type;
+      if (type.kind == 'NamedType') {
+        let schemaType = this.schema.getType(type.name.value);
+        if (isEnumType(schemaType)) {
+          this._enums.add(schemaType.name);
+        }
+      }
+    });
 
     const { enums, fragments, selections } = parseSelectionSet(
       this.schema,


### PR DESCRIPTION
Currently the enums are only generated if they're a part of the query result, but they can also be used as query parameters.
This PR grabs those enums.