### PR TITLE
Expand bounds per PVP

### DIFF
--- a/graphql-client/graphql-client.cabal
+++ b/graphql-client/graphql-client.cabal
@@ -4,7 +4,7 @@ cabal-version: >= 1.10
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7654e5355b218d6a20d41a8054d72ff6d0791d09baafdfda48d2e749ef0c3173
+-- hash: 18d4a7056eed06e8d4ebc7550f18597c2be3d08b6613d78da7858458620520a0
 
 name:           graphql-client
 version:        1.1.1
@@ -73,19 +73,19 @@ executable graphql-codegen
     , aeson-schemas ==1.3.*
     , base >=4.9 && <5
     , bytestring >=0.10.8.2 && <0.11
-    , file-embed >=0.0.10.1 && <0.0.15
+    , file-embed >=0.0.10.1 && <0.1
     , graphql-client
     , http-client >=0.5.13.1 && <0.8
     , http-client-tls >=0.3.5.3 && <0.4
     , http-types >=0.12.1 && <0.13
     , mtl >=2.2.2 && <2.3
-    , optparse-applicative >=0.14.2.0 && <0.16.2
+    , optparse-applicative >=0.14.2.0 && <0.17
     , path >=0.6.1 && <0.9
-    , path-io >=1.3.3 && <1.7.0
+    , path-io >=1.3.3 && <1.7
     , template-haskell >=2.12.0.0 && <3
     , text >=1.2.3.0 && <1.3
     , transformers >=0.5.2.0 && <0.6
-    , typed-process >=0.2.3.0 && <0.2.7
+    , typed-process >=0.2.3.0 && <0.3
     , unliftio-core >=0.1.1.0 && <0.3
   if impl(ghc >= 8.0)
     ghc-options: -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wnoncanonical-monad-instances

--- a/graphql-client/package.yaml
+++ b/graphql-client/package.yaml
@@ -54,12 +54,12 @@ executables:
     main: exe/Codegen.hs
     dependencies:
       - bytestring >= 0.10.8.2 && < 0.11
-      - file-embed >= 0.0.10.1 && < 0.0.15
+      - file-embed >= 0.0.10.1 && < 0.1
       - graphql-client
-      - optparse-applicative >= 0.14.2.0 && < 0.16.2
+      - optparse-applicative >= 0.14.2.0 && < 0.17
       - path >= 0.6.1 && < 0.9
-      - path-io >= 1.3.3 && < 1.7.0
-      - typed-process >= 0.2.3.0 && < 0.2.7
+      - path-io >= 1.3.3 && < 1.7
+      - typed-process >= 0.2.3.0 && < 0.3
 
 tests:
   graphql-client-test:


### PR DESCRIPTION
PVP does not treat 0.x differently, so these deps should be pinned to the nearest minor version.