### PR TITLE
Disable html escaping in Mustache

### DIFF
--- a/graphql-codegen-haskell/src/index.test.ts
+++ b/graphql-codegen-haskell/src/index.test.ts
@@ -271,6 +271,50 @@ it(`generates files using files from ${TEST_DIR}`, async () => {
         [ \\"s\\" .= _s (query :: GetNamed2Query)
         ]
 
+    {-----------------------------------------------------------------------------
+    -- getNamedWithLiteralParam
+
+    -- result :: Object GetNamedWithLiteralParamSchema; throws a GraphQL exception on errors
+    result <- runQuery GetNamedWithLiteralParamQuery
+      {
+      }
+
+    -- result :: GraphQLResult (Object GetNamedWithLiteralParamSchema)
+    result <- runQuerySafe GetNamedWithLiteralParamQuery
+      {
+      }
+    -----------------------------------------------------------------------------}
+
+    data GetNamedWithLiteralParamQuery = GetNamedWithLiteralParamQuery
+      {
+      }
+      deriving (Show)
+
+    type GetNamedWithLiteralParamSchema = [schema|
+      {
+        getNamed: Maybe {
+          name: Text,
+        },
+      }
+    |]
+
+    instance GraphQLQuery GetNamedWithLiteralParamQuery where
+      type ResultSchema GetNamedWithLiteralParamQuery = GetNamedWithLiteralParamSchema
+
+      getQueryName _ = \\"getNamedWithLiteralParam\\"
+
+      getQueryText _ = [query|
+        query getNamedWithLiteralParam {
+          getNamed(s: \\"LITERAL\\") {
+            name
+          }
+        }
+      |]
+
+      getArgs query = object
+        [
+        ]
+
     "
   `)
 

--- a/graphql-codegen-haskell/src/index.ts
+++ b/graphql-codegen-haskell/src/index.ts
@@ -5,6 +5,7 @@ import { UrlLoader } from '@graphql-tools/url-loader'
 import * as fs from 'fs'
 import { concatAST, DocumentNode, GraphQLSchema } from 'graphql'
 import * as yaml from 'js-yaml'
+import Mustache from 'mustache'
 import * as path from 'path'
 
 import { validateConfig } from './config'
@@ -70,6 +71,9 @@ export const generate = async (configPath: string): Promise<OutputFiles> => {
     const modulePath = moduleToPath(module, sourceDir)
     filesToGenerate[modulePath] = content
   }
+
+  // globally disable html-escaping
+  Mustache.escape = x => x
 
   addModule(
     config.apiModule,

--- a/graphql-codegen-haskell/src/render/templates/api.mustache
+++ b/graphql-codegen-haskell/src/render/templates/api.mustache
@@ -53,7 +53,7 @@ instance GraphQLQuery {{queryName}} where
   getQueryName _ = "{{name}}"
 
   getQueryText _ = [query|
-    {{{queryText}}}
+    {{queryText}}
   |]
 
   getArgs query = object

--- a/graphql-codegen-haskell/src/render/templates/api.mustache
+++ b/graphql-codegen-haskell/src/render/templates/api.mustache
@@ -53,7 +53,7 @@ instance GraphQLQuery {{queryName}} where
   getQueryName _ = "{{name}}"
 
   getQueryText _ = [query|
-    {{queryText}}
+    {{{queryText}}}
   |]
 
   getArgs query = object

--- a/graphql-codegen-haskell/test/document.graphql
+++ b/graphql-codegen-haskell/test/document.graphql
@@ -40,3 +40,9 @@ query getNamed2($s: String!) {
 fragment bar2 on Bar2 {
   id
 }
+
+query getNamedWithLiteralParam {
+  getNamed(s: "LITERAL") {
+    name
+  }
+}

--- a/graphql-codegen-haskell/test/schema.graphql
+++ b/graphql-codegen-haskell/test/schema.graphql
@@ -44,3 +44,4 @@ type Query {
   getNamed(s: String!): Named
   getNamed2(s: String!): Named2
 }
+


### PR DESCRIPTION
Solves #80 by globally disabling html escaping in Mustache templates.