### PR TITLE
Improve exception display for `GraphQLException` and `GraphQLError`

### DIFF
--- a/graphql-client/graphql-client.cabal
+++ b/graphql-client/graphql-client.cabal
@@ -83,6 +83,7 @@ test-suite graphql-client-test
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
+      Data.GraphQL.Test.Error
       Data.GraphQL.Test.Generation.TestGeneration
       Data.GraphQL.Test.Monad.Class
       Data.GraphQL.Test.TestQuery

--- a/graphql-client/src/Data/GraphQL/Error.hs
+++ b/graphql-client/src/Data/GraphQL/Error.hs
@@ -39,6 +39,7 @@ displayGraphQLError indentFirst indentRest exception =
     <> "At "
     <> joinWithCommas (maybe [] (map displayErrorLoc) (locations exception))
     <> ": "
+    -- Note: If this message contains multiple lines, subsequent lines will not be indented correctly.
     <> unpack (message exception)
     <> maybe "" (nextLine "Path: " . joinWithCommas . map valueToString) (path exception)
     <> maybe "" (nextLine "Extensions: " . valueToString) (extensions exception)

--- a/graphql-client/src/Data/GraphQL/Error.hs
+++ b/graphql-client/src/Data/GraphQL/Error.hs
@@ -16,9 +16,12 @@ module Data.GraphQL.Error (
   GraphQLException (..),
 ) where
 
-import Control.Exception (Exception)
+import Control.Exception (Exception (..))
 import Data.Aeson (FromJSON (..), ToJSON, Value, withObject, (.:))
-import Data.Text (Text)
+import Data.Aeson.Text (encodeToLazyText)
+import Data.List (intersperse)
+import Data.Text (Text, unpack)
+import Data.Text.Lazy (toStrict)
 import GHC.Generics (Generic)
 
 -- | An error in a GraphQL query.
@@ -30,12 +33,30 @@ data GraphQLError = GraphQLError
   }
   deriving (Show, Eq, Generic, ToJSON, FromJSON)
 
+instance Exception GraphQLError where
+  displayException exception =
+    "At "
+      <> joinWithCommas (maybe [] (map displayErrorLoc) (locations exception))
+      <> ": "
+      <> unpack (message exception)
+      <> maybe "" (("\nPath: " <>) . joinWithCommas . map valueToString) (path exception)
+      <> maybe "" (("\nExtensions: " <>) . valueToString) (extensions exception)
+    where
+      joinWithCommas = unwords . intersperse ", "
+
+      valueToString :: Value -> String
+      valueToString = unpack . toStrict . encodeToLazyText
+
 -- | A location in an error in a GraphQL query.
 data GraphQLErrorLoc = GraphQLErrorLoc
   { errorLine :: Int
   , errorCol :: Int
   }
   deriving (Show, Eq, Generic, ToJSON)
+
+displayErrorLoc :: GraphQLErrorLoc -> String
+displayErrorLoc errorLoc =
+  show (errorLine errorLoc) <> ":" <> show (errorCol errorLoc)
 
 instance FromJSON GraphQLErrorLoc where
   parseJSON = withObject "GraphQLErrorLoc" $ \o ->
@@ -45,4 +66,9 @@ instance FromJSON GraphQLErrorLoc where
 
 -- | An exception thrown as a result of an error in a GraphQL query.
 newtype GraphQLException = GraphQLException [GraphQLError]
-  deriving (Show, Exception, Eq)
+  deriving (Show, Eq)
+
+instance Exception GraphQLException where
+  displayException (GraphQLException errors) =
+    "GraphQL errors:\n"
+      <> concat (intersperse "\n\n" $ map displayException errors)

--- a/graphql-client/test/Data/GraphQL/Test/Error.hs
+++ b/graphql-client/test/Data/GraphQL/Test/Error.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Data.GraphQL.Test.Error where
+
+import Control.Exception (Exception(..))
+import Data.Aeson.KeyMap (fromList)
+import qualified Data.Aeson.Types as Aeson
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@?=))
+
+import Data.GraphQL.Error (GraphQLError (..), GraphQLException (..), GraphQLErrorLoc (..))
+
+testErrorDisplay :: TestTree
+testErrorDisplay =
+  testGroup
+    "GraphQLException"
+    [ testCase "displayException" $ do
+        let err =
+              GraphQLException
+                [ GraphQLError
+                    -- TODO: What do actual error messages look like?
+                    { message = "Something went wrong!"
+                    , locations = Just [GraphQLErrorLoc { errorLine = 10, errorCol = 3 }]
+                    , path = Just [ Aeson.String "my_query.graphql" ]
+                    , extensions = Just (Aeson.Object (fromList [("complexity", Aeson.Number 2)]))
+                    }
+                ]
+        displayException err @?=
+          "GraphQL errors:\n"
+          <> "At 10:3: Something went wrong!\n"
+          <> "Path: \"my_query.graphql\"\n"
+          <> "Extensions: {\"complexity\":2}"
+    ]

--- a/graphql-client/test/Data/GraphQL/Test/Error.hs
+++ b/graphql-client/test/Data/GraphQL/Test/Error.hs
@@ -1,18 +1,15 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes #-}
 
 module Data.GraphQL.Test.Error where
 
-import Control.Exception (Exception(..))
+import Control.Exception (Exception (..))
 import Data.Aeson.KeyMap (fromList)
 import qualified Data.Aeson.Types as Aeson
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase, (@?=))
 
-import Data.GraphQL.Error (GraphQLError (..), GraphQLException (..), GraphQLErrorLoc (..))
+import Data.GraphQL.Error (GraphQLError (..), GraphQLErrorLoc (..), GraphQLException (..))
 
 testErrorDisplay :: TestTree
 testErrorDisplay =
@@ -22,16 +19,16 @@ testErrorDisplay =
         let err =
               GraphQLException
                 [ GraphQLError
-                    -- TODO: What do actual error messages look like?
-                    { message = "Something went wrong!"
-                    , locations = Just [GraphQLErrorLoc { errorLine = 10, errorCol = 3 }]
-                    , path = Just [ Aeson.String "my_query.graphql" ]
+                    { -- TODO: What do actual error messages look like?
+                      message = "Something went wrong!"
+                    , locations = Just [GraphQLErrorLoc{errorLine = 10, errorCol = 3}]
+                    , path = Just [Aeson.String "my_query.graphql"]
                     , extensions = Just (Aeson.Object (fromList [("complexity", Aeson.Number 2)]))
                     }
                 ]
-        displayException err @?=
-          "GraphQL errors:\n"
-          <> "At 10:3: Something went wrong!\n"
-          <> "Path: \"my_query.graphql\"\n"
-          <> "Extensions: {\"complexity\":2}"
+        displayException err
+          @?= "GraphQL errors:\n"
+          <> "* At 10:3: Something went wrong!\n"
+          <> "  Path: \"my_query.graphql\"\n"
+          <> "  Extensions: {\"complexity\":2}"
     ]

--- a/graphql-client/test/Main.hs
+++ b/graphql-client/test/Main.hs
@@ -1,5 +1,6 @@
 import Test.Tasty (defaultMain, testGroup)
 
+import Data.GraphQL.Test.Error
 import Data.GraphQL.Test.Generation.TestGeneration
 import Data.GraphQL.Test.Monad.Class
 import Data.GraphQL.Test.TestUtils
@@ -12,4 +13,5 @@ main =
       [ testRunQuery
       , testTestUtils
       , testGeneration
+      , testErrorDisplay
       ]


### PR DESCRIPTION
Before:

    GraphQLException [GraphQLError {message = "Something went wrong!", locations = Just [GraphQLErrorLoc {errorLine = 10, errorCol = 3}], path = Just [String "my_query.graphql"], extensions = Just (Object (fromList [("complexity",Number 2.0)]))}]

After:

    GraphQL errors:
    At 10:3: Something went wrong!
    Path: "my_query.graphql"
    Extensions: {"complexity":2}

Closes #91